### PR TITLE
Upgrade jsonapi renderer

### DIFF
--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,8 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.2']
+  # spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.2']
+  spec.add_runtime_dependency 'jsonapi-renderer', ['~> 0.2']
   spec.add_runtime_dependency 'case_transform', '>= 0.2'
 
   spec.add_development_dependency 'activerecord', rails_versions

--- a/active_model_serializers.gemspec
+++ b/active_model_serializers.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |spec|
   # 'minitest'
   # 'thread_safe'
 
-  # spec.add_runtime_dependency 'jsonapi-renderer', ['>= 0.1.1.beta1', '< 0.2']
   spec.add_runtime_dependency 'jsonapi-renderer', ['~> 0.2']
   spec.add_runtime_dependency 'case_transform', '>= 0.2'
 


### PR DESCRIPTION

Change version of jsonapi-renderer to be able to use jsonapi and active model serializer at the same time in jobtestmarket